### PR TITLE
Release for v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.0.3](https://github.com/chaspy/gh-monorepo-stats/compare/v0.0.2...v0.0.3) - 2024-01-22
+- ignore dot dir by @chaspy in https://github.com/chaspy/gh-monorepo-stats/pull/10
+
 ## [v0.0.2](https://github.com/chaspy/gh-monorepo-stats/compare/v0.0.1...v0.0.2) - 2024-01-22
 - Enable tagpr by @chaspy in https://github.com/chaspy/gh-monorepo-stats/pull/5
 - Add renovate.json by @chaspy in https://github.com/chaspy/gh-monorepo-stats/pull/6


### PR DESCRIPTION
This pull request is for the next release as v0.0.3 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.3 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* ignore dot dir by @chaspy in https://github.com/chaspy/gh-monorepo-stats/pull/10


**Full Changelog**: https://github.com/chaspy/gh-monorepo-stats/compare/v0.0.2...v0.0.3