### PR TITLE
Release for v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.0.5](https://github.com/chaspy/gh-monorepo-stats/compare/v0.0.4...v0.0.5) - 2024-05-05
+- Allow ignore file by @chaspy in https://github.com/chaspy/gh-monorepo-stats/pull/18
+
 ## [v0.0.4](https://github.com/chaspy/gh-monorepo-stats/compare/v0.0.3...v0.0.4) - 2024-01-24
 - Support ignore dirs by @chaspy in https://github.com/chaspy/gh-monorepo-stats/pull/12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v0.0.5](https://github.com/chaspy/gh-monorepo-stats/compare/v0.0.4...v0.0.5) - 2024-05-05
+## [v0.1.0](https://github.com/chaspy/gh-monorepo-stats/compare/v0.0.4...v0.1.0) - 2024-05-05
 - Allow ignore file by @chaspy in https://github.com/chaspy/gh-monorepo-stats/pull/18
 
 ## [v0.0.4](https://github.com/chaspy/gh-monorepo-stats/compare/v0.0.3...v0.0.4) - 2024-01-24


### PR DESCRIPTION
This pull request is for the next release as v0.0.5 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.5 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.4" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Allow ignore file by @chaspy in https://github.com/chaspy/gh-monorepo-stats/pull/18


**Full Changelog**: https://github.com/chaspy/gh-monorepo-stats/compare/v0.0.4...v0.0.5